### PR TITLE
Fix a bug: 連文節の検索が出来ない

### DIFF
--- a/autoload/kensaku_search.vim
+++ b/autoload/kensaku_search.vim
@@ -17,5 +17,5 @@ endfunction
 " https://github.com/rhysd/migemo-search.vim/blob/25fc2f029eb24d1178ee34ceaefa23da17f70c7e/plugin/migemosearch.vim#L12-L19
 call s:define(
       \ 'kensaku_search#pattern',
-      \ '^\%(\\\a\)\=\zs\(\(\(\([bdfghjklmnpstrzwx]\)\4\=\)\=y\=\([ei]\|[aou]h\=\)\)\|\%(ss\=\|dd\=\)\=h[aiuo]\|cc\=h[aio]\|tt\=su\|n\|-\)\+$'
+      \ '\c^\%(\\\a\)\=\zs\(\(\(\([bdfghjklmnpstrzwx]\)\4\=\)\=y\=\([ei]\|[aou]h\=\)\)\|\%(ss\=\|dd\=\)\=h[aiuo]\|cc\=h[aio]\|tt\=su\|n\|-\)\+$'
       \)


### PR DESCRIPTION
コマンドラインで検索する文字列がローマ字列であるかどうか判断する正規表現が、小文字にしか対応していないため、表題のバグが出ていました。
(js)migemo では連文節の検索に SKK のスタイルを踏襲しています。
  e.g.「家で寝よう」→ "ieDeNeYou"
ローマ字列を判断する正規表現を case insensitive にすることで対応しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved search functionality by making pattern matching case-insensitive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->